### PR TITLE
Initialize default schedule members and fix CORS origins

### DIFF
--- a/api/schedule_routes.py
+++ b/api/schedule_routes.py
@@ -339,16 +339,16 @@ def get_family_members(current_user):
 
     if not ms:
         default_members = [
-            {"id": "rut", "name": "Rut", "color": "#FF6B6B", "icon": "👧"},
-            {"id": "pim", "name": "Pim", "color": "#4E9FFF", "icon": "👦"},
-            {"id": "siv", "name": "Siv", "color": "#6BCF7F", "icon": "👧"},
-            {"id": "mamma", "name": "Mamma", "color": "#A020F0", "icon": "👩"},
-            {"id": "pappa", "name": "Pappa", "color": "#FF9F45", "icon": "👨"},
+            {"name": "Rut", "color": "#FF6B6B", "icon": "👧"},
+            {"name": "Pim", "color": "#4E9FFF", "icon": "👦"},
+            {"name": "Siv", "color": "#6BCF7F", "icon": "👧"},
+            {"name": "Mamma", "color": "#A020F0", "icon": "👩"},
+            {"name": "Pappa", "color": "#FF9F45", "icon": "👨"},
         ]
 
         for member_data in default_members:
             member = FamilyMember(
-                id=member_data["id"],
+                id=str(uuid.uuid4()),
                 user_id=current_user.id,
                 name=member_data["name"],
                 color=member_data["color"],

--- a/config/settings.py
+++ b/config/settings.py
@@ -38,7 +38,7 @@ CORS_ORIGINS = [
     'https://drive-c-frontend.vercel.app', # In case the URL changes to production
     'https://drive-c-frontend-git-split-tobias-lundhs-projects.vercel.app',
     'https://drive-c-frontend-5q8e56t64-tobias-lundhs-projects.vercel.app',
-    'https://drive-c-frontend-git-main-2-tobias-lundhs-projects.vercel.app/login',
+    'https://drive-c-frontend-git-main-2-tobias-lundhs-projects.vercel.app',
     os.environ.get('FRONTEND_URL', ''),  # From environment variable
 ]
 


### PR DESCRIPTION
## Summary
- initialize default family members with unique IDs and include color in responses
- allow frontend CORS origin without path component

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcb6b5e5e48323b7a493fef851a55d