### PR TITLE
Remove redundant preflight handlers

### DIFF
--- a/api/auth_routes.py
+++ b/api/auth_routes.py
@@ -76,17 +76,10 @@ class JWT:
 jwt = JWT
 from config.settings import SECRET_KEY
 
-# ---- Preflight: svara 204 tidigt så auth inte körs ----
-@auth.before_request
-def auth_handle_preflight():
-    if request.method == "OPTIONS":
-        return ("", 204)
-
-# ---- Auth-dekorator (berör inte OPTIONS) ----
+# ---- Auth-dekorator (OPTIONS passas vidare utan validering) ----
 def token_required(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        # Preflight fångas redan i before_request
         auth_header = request.headers.get("Authorization", "")
         token = auth_header.split(" ", 1)[1] if auth_header.startswith("Bearer ") else None
         if not token:

--- a/api/schedule_routes.py
+++ b/api/schedule_routes.py
@@ -13,12 +13,6 @@ import logging
 logger = logging.getLogger(__name__)
 schedule_bp = Blueprint('schedule_bp', __name__)
 
-# ---------------- CORS preflight (behåll) ----------------
-@schedule_bp.before_request
-def schedule_handle_preflight():
-    if request.method == 'OPTIONS':
-        return ("", 204)
-
 # ---------------- Retry-hjälpare ----------------
 def retry_on_connection_error(func):
     """Retry DB-operationer som kan kasta OperationalError (t.ex. tappad MySQL-anslutning)."""

--- a/app.py
+++ b/app.py
@@ -39,12 +39,6 @@ def create_app():
         intercept_exceptions=False,
     )
 
-    # --- Global preflight: svara TIDIGT med tom 204 för alla /api/* ---
-    @app.before_request
-    def global_preflight():
-        if request.method == "OPTIONS" and request.path.startswith("/api/"):
-            return ("", 204)
-
     # (Valfritt men robust): spegla begärda headers på preflight
     @app.after_request
     def mirror_requested_cors_headers(resp):


### PR DESCRIPTION
## Summary
- Remove manual preflight handlers from app, auth, and schedule blueprints
- Rely on Flask-CORS for `/api/*` OPTIONS requests with explicit methods and headers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `curl -i -X OPTIONS http://127.0.0.1:5001/api/auth/login -H "Origin: http://localhost:3000" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: Authorization, Content-Type"`


------
https://chatgpt.com/codex/tasks/task_e_68bcbb5c96188323b5aafb21c9c1adc4