### PR TITLE
Refactor auth and standardize API responses

### DIFF
--- a/api/auth_routes.py
+++ b/api/auth_routes.py
@@ -3,78 +3,22 @@ from flask import Blueprint, jsonify, request
 from services.db_config import db
 from models.user import User
 from functools import wraps
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 import logging
-import json, base64, hmac, hashlib
+import jwt
+
+from config.settings import SECRET_KEY
 
 logger = logging.getLogger(__name__)
 auth = Blueprint('auth', __name__)
 
-# ---- Minimal, säker fallback-JWT (HS256) ----
-def _b64url_encode(b: bytes) -> str:
-    return base64.urlsafe_b64encode(b).decode().rstrip("=")
 
-def _b64url_decode(s: str) -> bytes:
-    pad = '=' * (-len(s) % 4)
-    return base64.urlsafe_b64decode(s + pad)
+def success_response(data=None, status_code=200):
+    return jsonify({"success": True, "data": data if data is not None else {}, "error": None}), status_code
 
-class JWT:
-    @staticmethod
-    def encode(payload: dict, key: str, algorithm: str = "HS256") -> str:
-        if algorithm != "HS256":
-            raise ValueError("Only HS256 is supported by this fallback JWT.")
-        header = {"alg": "HS256", "typ": "JWT"}
 
-        # Standard-claims (läggs till om saknas)
-        now = datetime.now(timezone.utc)
-        payload = dict(payload)  # kopia så vi ej muterar anroparens dict
-        payload.setdefault("iat", int(now.timestamp()))
-        payload.setdefault("exp", int((now + timedelta(days=7)).timestamp()))
-
-        header_b64 = _b64url_encode(json.dumps(header, separators=(",", ":"), ensure_ascii=False).encode())
-        payload_b64 = _b64url_encode(json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode())
-        signing_input = f"{header_b64}.{payload_b64}".encode()
-        sig = hmac.new(key.encode(), signing_input, hashlib.sha256).digest()
-        signature_b64 = _b64url_encode(sig)
-        return f"{header_b64}.{payload_b64}.{signature_b64}"
-
-    @staticmethod
-    def decode(token: str, key: str, algorithms=None) -> dict:
-        if algorithms is None:
-            algorithms = ["HS256"]
-        parts = token.split(".")
-        if len(parts) != 3:
-            raise Exception("Invalid token format")
-        header_b64, payload_b64, signature_b64 = parts
-
-        header = json.loads(_b64url_decode(header_b64))
-        alg = header.get("alg")
-        if alg not in algorithms or alg != "HS256":
-            raise Exception("Unsupported or disallowed algorithm")
-
-        # Verifiera signatur (konstant tidsjämförelse)
-        signing_input = f"{header_b64}.{payload_b64}".encode()
-        expected_sig = hmac.new(key.encode(), signing_input, hashlib.sha256).digest()
-        expected_sig_b64 = _b64url_encode(expected_sig)
-        if not hmac.compare_digest(signature_b64, expected_sig_b64):
-            raise Exception("Invalid signature")
-
-        payload = json.loads(_b64url_decode(payload_b64))
-
-        # Expirations- och nbf-kontroller
-        now_ts = int(datetime.now(timezone.utc).timestamp())
-        nbf = payload.get("nbf")
-        exp = payload.get("exp")
-        if nbf is not None and now_ts < int(nbf):
-            raise Exception("Token not yet valid")
-        if exp is not None and now_ts >= int(exp):
-            raise Exception("Token has expired")
-
-        return payload
-
-# Använd klassens statiska metoder via 'jwt'
-jwt = JWT
-from config.settings import SECRET_KEY
+def error_response(message, status_code=400, data=None):
+    return jsonify({"success": False, "data": data, "error": message}), status_code
 
 # ---- Auth-dekorator (OPTIONS passas vidare utan validering) ----
 def token_required(f):
@@ -83,18 +27,18 @@ def token_required(f):
         auth_header = request.headers.get("Authorization", "")
         token = auth_header.split(" ", 1)[1] if auth_header.startswith("Bearer ") else None
         if not token:
-            return jsonify({'status': 'error', 'message': 'Authentication token is missing'}), 401
+            return error_response('Authentication token is missing', 401)
         try:
             data = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
             user_id = data.get('user_id')
             if not user_id:
-                return jsonify({'status': 'error', 'message': 'Invalid authentication token'}), 401
+                return error_response('Invalid authentication token', 401)
             user = User.query.filter_by(id=user_id).first()
             if not user:
-                return jsonify({'status': 'error', 'message': 'Invalid authentication token'}), 401
+                return error_response('Invalid authentication token', 401)
         except Exception as e:
             logger.error(f"Token validation error: {str(e)}")
-            return jsonify({'status': 'error', 'message': 'Invalid authentication token'}), 401
+            return error_response('Invalid authentication token', 401)
         return f(user, *args, **kwargs)
     return decorated
 
@@ -106,11 +50,11 @@ def login():
         username = (auth_data.get('username') or "").strip()
         password = auth_data.get('password')
         if not username or not password:
-            return jsonify({'status': 'error', 'message': 'Username and password are required'}), 400
+            return error_response('Username and password are required', 400)
 
         user = User.query.filter_by(username=username).first()
         if not user or not user.check_password(password):
-            return jsonify({'status': 'error', 'message': 'Invalid credentials'}), 401
+            return error_response('Invalid credentials', 401)
 
         user.last_login = datetime.utcnow()
         db.session.commit()
@@ -119,15 +63,15 @@ def login():
             {
                 'user_id': user.id,
                 'username': user.username,
-                # exp sätts i encode() om saknas
+                'exp': datetime.utcnow() + timedelta(days=7)
             },
             SECRET_KEY,
             algorithm="HS256"
         )
-        return jsonify({'status': 'success', 'data': {'token': token, 'user': user.to_dict()}})
+        return success_response({'token': token, 'user': user.to_dict()})
     except Exception as e:
         logger.error(f"Login error: {str(e)}")
-        return jsonify({'status': 'error', 'message': 'Login failed'}), 500
+        return error_response('Login failed', 500)
 
 @auth.route('/register', methods=['POST'])
 def register():
@@ -136,10 +80,10 @@ def register():
         username = (data.get('username') or "").strip()
         password = data.get('password')
         if not username or not password:
-            return jsonify({'status': 'error', 'message': 'Username and password are required'}), 400
+            return error_response('Username and password are required', 400)
 
         if User.query.filter_by(username=username).first():
-            return jsonify({'status': 'error', 'message': 'Username already taken'}), 400
+            return error_response('Username already taken', 400)
 
         new_user = User(
             id=User.generate_id(),
@@ -155,21 +99,22 @@ def register():
             {
                 'user_id': new_user.id,
                 'username': new_user.username,
+                'exp': datetime.utcnow() + timedelta(days=7)
             },
             SECRET_KEY,
             algorithm="HS256"
         )
-        return jsonify({'status': 'success', 'data': {'token': token, 'user': new_user.to_dict()}}), 201
+        return success_response({'token': token, 'user': new_user.to_dict()}, 201)
     except Exception as e:
         logger.error(f"Registration error: {str(e)}")
         db.session.rollback()
-        return jsonify({'status': 'error', 'message': 'Registration failed'}), 500
+        return error_response('Registration failed', 500)
 
 @auth.route('/me', methods=['GET'])
 @token_required
 def get_user_profile(current_user):
     try:
-        return jsonify({'status': 'success', 'data': current_user.to_dict()})
+        return success_response(current_user.to_dict())
     except Exception as e:
         logger.error(f"Profile fetch error: {str(e)}")
-        return jsonify({'status': 'error', 'message': 'Failed to get profile'}), 500
+        return error_response('Failed to get profile', 500)

--- a/api/calendar_routes.py
+++ b/api/calendar_routes.py
@@ -9,11 +9,13 @@ import logging
 logger = logging.getLogger(__name__)
 calendar_api = Blueprint('calendar_api', __name__)
 
-# --- Preflight: svara tom 204 så dekorerare/body-parsing aldrig körs ---
-@calendar_api.before_request
-def calendar_handle_preflight():
-    if request.method == 'OPTIONS':
-        return ("", 204)
+
+def success_response(data=None, status_code=200):
+    return jsonify({"success": True, "data": data if data is not None else {}, "error": None}), status_code
+
+
+def error_response(message, status_code=400, data=None):
+    return jsonify({"success": False, "data": data, "error": message}), status_code
 
 # --- Hjälpare för tidskonvertering (lagras som "naive UTC" i DB) ---
 def ms_to_naive_utc(ms):
@@ -43,17 +45,17 @@ def get_events(current_user):
                 start_dt = ms_to_naive_utc(start_ts)
                 query = query.filter(CalendarEvent.start_time >= start_dt)
             except Exception:
-                return jsonify({"status": "error", "message": "Invalid start timestamp format"}), 400
+                return error_response("Invalid start timestamp format", 400)
 
         if end_ts:
             try:
                 end_dt = ms_to_naive_utc(end_ts)
                 query = query.filter(CalendarEvent.end_time <= end_dt)
             except Exception:
-                return jsonify({"status": "error", "message": "Invalid end timestamp format"}), 400
+                return error_response("Invalid end timestamp format", 400)
 
         if start_dt and end_dt and end_dt < start_dt:
-            return jsonify({"status": "error", "message": "end must be >= start"}), 400
+            return error_response("end must be >= start", 400)
 
         events = query.order_by(CalendarEvent.start_time.asc()).all()
 
@@ -66,11 +68,11 @@ def get_events(current_user):
             'color': e.color
         } for e in events]
 
-        return jsonify({"status": "success", "data": events_data})
+        return success_response(events_data)
 
     except Exception as e:
         logger.error(f"Error in get_events: {str(e)}")
-        return jsonify({"status": "error", "message": "Failed to fetch events"}), 500
+        return error_response("Failed to fetch events", 500)
 
 
 @calendar_api.route('/events', methods=['POST'])
@@ -82,16 +84,16 @@ def create_event(current_user):
         required = ['title', 'start', 'end']
         missing = [f for f in required if f not in data]
         if missing:
-            return jsonify({"status": "error", "message": f"Missing required field(s): {', '.join(missing)}"}), 400
+            return error_response(f"Missing required field(s): {', '.join(missing)}", 400)
 
         try:
             start_time = ms_to_naive_utc(data['start'])
             end_time = ms_to_naive_utc(data['end'])
         except Exception:
-            return jsonify({"status": "error", "message": "Invalid timestamp format. Use milliseconds since epoch."}), 400
+            return error_response("Invalid timestamp format. Use milliseconds since epoch.", 400)
 
         if end_time < start_time:
-            return jsonify({"status": "error", "message": "end must be >= start"}), 400
+            return error_response("end must be >= start", 400)
 
         new_event = CalendarEvent(
             id=CalendarEvent.generate_id(),
@@ -105,22 +107,19 @@ def create_event(current_user):
         db.session.add(new_event)
         db.session.commit()
 
-        return jsonify({
-            "status": "success",
-            "data": {
-                'id': new_event.id,
-                'title': new_event.title,
-                'start': naive_utc_to_ms(new_event.start_time),
-                'end': naive_utc_to_ms(new_event.end_time),
-                'notes': new_event.notes,
-                'color': new_event.color
-            }
-        }), 201
+        return success_response({
+            'id': new_event.id,
+            'title': new_event.title,
+            'start': naive_utc_to_ms(new_event.start_time),
+            'end': naive_utc_to_ms(new_event.end_time),
+            'notes': new_event.notes,
+            'color': new_event.color
+        }, 201)
 
     except Exception as e:
         logger.error(f"Error in create_event: {str(e)}")
         db.session.rollback()
-        return jsonify({"status": "error", "message": "Failed to create event"}), 500
+        return error_response("Failed to create event", 500)
 
 
 @calendar_api.route('/events/<event_id>', methods=['PUT'])
@@ -131,7 +130,7 @@ def update_event(current_user, event_id):
         data = request.get_json(silent=True) or {}
         event = CalendarEvent.query.filter_by(id=event_id, user_id=current_user.id).first()
         if not event:
-            return jsonify({"status": "error", "message": "Event not found"}), 404
+            return error_response("Event not found", 404)
 
         # Temporära värden för validering av start/end
         new_start = event.start_time
@@ -144,16 +143,16 @@ def update_event(current_user, event_id):
             try:
                 new_start = ms_to_naive_utc(data['start'])
             except Exception:
-                return jsonify({"status": "error", "message": "Invalid start timestamp format"}), 400
+                return error_response("Invalid start timestamp format", 400)
 
         if 'end' in data:
             try:
                 new_end = ms_to_naive_utc(data['end'])
             except Exception:
-                return jsonify({"status": "error", "message": "Invalid end timestamp format"}), 400
+                return error_response("Invalid end timestamp format", 400)
 
         if new_end < new_start:
-            return jsonify({"status": "error", "message": "end must be >= start"}), 400
+            return error_response("end must be >= start", 400)
 
         event.start_time = new_start
         event.end_time = new_end
@@ -165,22 +164,19 @@ def update_event(current_user, event_id):
 
         db.session.commit()
 
-        return jsonify({
-            "status": "success",
-            "data": {
-                'id': event.id,
-                'title': event.title,
-                'start': naive_utc_to_ms(event.start_time),
-                'end': naive_utc_to_ms(event.end_time),
-                'notes': event.notes,
-                'color': event.color
-            }
+        return success_response({
+            'id': event.id,
+            'title': event.title,
+            'start': naive_utc_to_ms(event.start_time),
+            'end': naive_utc_to_ms(event.end_time),
+            'notes': event.notes,
+            'color': event.color
         })
 
     except Exception as e:
         logger.error(f"Error in update_event: {str(e)}")
         db.session.rollback()
-        return jsonify({"status": "error", "message": "Failed to update event"}), 500
+        return error_response("Failed to update event", 500)
 
 
 @calendar_api.route('/events/<event_id>', methods=['DELETE'])
@@ -190,17 +186,17 @@ def delete_event(current_user, event_id):
     try:
         event = CalendarEvent.query.filter_by(id=event_id, user_id=current_user.id).first()
         if not event:
-            return jsonify({"status": "error", "message": "Event not found"}), 404
+            return error_response("Event not found", 404)
 
         db.session.delete(event)
         db.session.commit()
-        return jsonify({"status": "success", "message": "Event deleted successfully"})
+        return success_response({"message": "Event deleted successfully"})
         # (Alternativt: return ("", 204))
 
     except Exception as e:
         logger.error(f"Error in delete_event: {str(e)}")
         db.session.rollback()
-        return jsonify({"status": "error", "message": "Failed to delete event"}), 500
+        return error_response("Failed to delete event", 500)
 
 # --------------------- Day Notes endpoints ---------------------
 
@@ -212,24 +208,21 @@ def get_day_note(current_user, date_str):
         try:
             day_date = date.fromisoformat(date_str)
         except ValueError:
-            return jsonify({"status": "error", "message": "Invalid date format. Use YYYY-MM-DD."}), 400
+            return error_response("Invalid date format. Use YYYY-MM-DD.", 400)
 
         note = DayNote.query.filter_by(date=day_date, user_id=current_user.id).first()
         if not note:
-            return jsonify({"status": "success", "data": {"date": date_str, "notes": ""}})
+            return success_response({"date": date_str, "notes": ""})
 
-        return jsonify({
-            "status": "success",
-            "data": {
-                "id": note.id,
-                "date": note.date.isoformat(),
-                "notes": note.notes
-            }
+        return success_response({
+            "id": note.id,
+            "date": note.date.isoformat(),
+            "notes": note.notes
         })
 
     except Exception as e:
         logger.error(f"Error in get_day_note: {str(e)}")
-        return jsonify({"status": "error", "message": "Failed to fetch day note"}), 500
+        return error_response("Failed to fetch day note", 500)
 
 
 @calendar_api.route('/notes/<date_str>', methods=['POST', 'PUT'])
@@ -240,11 +233,11 @@ def save_day_note(current_user, date_str):
         try:
             day_date = date.fromisoformat(date_str)
         except ValueError:
-            return jsonify({"status": "error", "message": "Invalid date format. Use YYYY-MM-DD."}), 400
+            return error_response("Invalid date format. Use YYYY-MM-DD.", 400)
 
         data = request.get_json(silent=True) or {}
         if 'notes' not in data:
-            return jsonify({"status": "error", "message": "Missing required field: notes"}), 400
+            return error_response("Missing required field: notes", 400)
 
         note = DayNote.query.filter_by(date=day_date, user_id=current_user.id).first()
         if note:
@@ -261,16 +254,13 @@ def save_day_note(current_user, date_str):
 
         db.session.commit()
 
-        return jsonify({
-            "status": "success",
-            "data": {
-                "id": note.id,
-                "date": note.date.isoformat(),
-                "notes": note.notes
-            }
+        return success_response({
+            "id": note.id,
+            "date": note.date.isoformat(),
+            "notes": note.notes
         })
 
     except Exception as e:
         logger.error(f"Error in save_day_note: {str(e)}")
         db.session.rollback()
-        return jsonify({"status": "error", "message": "Failed to save day note"}), 500
+        return error_response("Failed to save day note", 500)


### PR DESCRIPTION
## Summary
- Replace custom JWT with PyJWT and unify auth responses
- Remove per-blueprint preflight handlers and use consistent JSON success/error helpers
- Enable credentials in CORS, add global error handler, and use `db.session` for updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd7450844883239466a72e2950828a