### PR TITLE
Simplify schedule participant handling and improve error logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from config.settings import (
 )
 import logging
 import os
+import traceback
 
 # Konfigurera loggning
 logging.basicConfig(level=logging.INFO)
@@ -79,7 +80,8 @@ def create_app():
 
     @app.errorhandler(Exception)
     def handle_exception(error):
-        logger.exception("Unhandled server error")
+        # Logga hela stack trace för att underlätta felsökning
+        logger.error(traceback.format_exc())
         db.session.rollback()
         return error_response("Internal server error", 500)
 


### PR DESCRIPTION
## Summary
- Expect `participants` to always be an array when creating schedule activities
- Log full exception stack traces to aid debugging

## Testing
- `pytest -q`
- `python -m py_compile api/schedule_routes.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdf957c8e883238dc3bb9d405c1fce