### PR TITLE
Add secure AI schedule parsing endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ PyMySQL
 bcrypt
 PyJWT
 python-dotenv
+requests>=2.32.0
+tenacity>=8.2.0
+python-dateutil>=2.9.0

--- a/services/ai_postprocess.py
+++ b/services/ai_postprocess.py
@@ -1,0 +1,287 @@
+"""Normalize AI-generated activities to importer schema."""
+from __future__ import annotations
+
+from datetime import date, datetime
+import os
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+from dateutil import parser as date_parser
+
+SWEDISH_DAYS: List[str] = [
+    "Måndag",
+    "Tisdag",
+    "Onsdag",
+    "Torsdag",
+    "Fredag",
+    "Lördag",
+    "Söndag",
+]
+
+_DAY_NORMALIZATION = {
+    "mandag": "Måndag",
+    "måndag": "Måndag",
+    "mån": "Måndag",
+    "monday": "Måndag",
+    "tisdag": "Tisdag",
+    "tis": "Tisdag",
+    "tuesday": "Tisdag",
+    "onsdag": "Onsdag",
+    "ons": "Onsdag",
+    "wednesday": "Onsdag",
+    "torsdag": "Torsdag",
+    "tor": "Torsdag",
+    "tors": "Torsdag",
+    "thursday": "Torsdag",
+    "fredag": "Fredag",
+    "fre": "Fredag",
+    "fred": "Fredag",
+    "friday": "Fredag",
+    "lordag": "Lördag",
+    "lördag": "Lördag",
+    "lör": "Lördag",
+    "lörs": "Lördag",
+    "saturday": "Lördag",
+    "sondag": "Söndag",
+    "söndag": "Söndag",
+    "sön": "Söndag",
+    "sunday": "Söndag",
+}
+
+
+def _strict_unknown_participants() -> bool:
+    return os.getenv("AI_PARSE_STRICT_UNKNOWN_PARTICIPANTS", "0") == "1"
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_date(value: Any) -> date:
+    if isinstance(value, (datetime, date)):
+        return value.date() if isinstance(value, datetime) else value
+    if not isinstance(value, str):
+        raise ValueError("Expected date string")
+    try:
+        parsed = date_parser.isoparse(value)
+    except (ValueError, TypeError):
+        parsed = date_parser.parse(value)
+    return parsed.date()
+
+
+def _date_components(value: Any) -> Tuple[str, int, int]:
+    d = _parse_date(value)
+    iso = d.isocalendar()
+    day_name = SWEDISH_DAYS[iso.weekday - 1]
+    return day_name, iso.week, iso.year
+
+
+def _normalize_day_label(day: Any) -> Optional[str]:
+    if not isinstance(day, str):
+        return None
+    stripped = day.strip()
+    if not stripped:
+        return None
+    lowered = stripped.lower()
+    normalized = _DAY_NORMALIZATION.get(lowered)
+    if normalized:
+        return normalized
+    capitalized = stripped.capitalize()
+    return capitalized if capitalized in SWEDISH_DAYS else None
+
+
+def expand_dates_to_week_schema(
+    items: Iterable[Mapping[str, Any]],
+    default_week: Optional[int] = None,
+    default_year: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    results: List[Dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+
+        base: Dict[str, Any] = dict(item)
+        date_value = base.pop("date", None)
+        dates_value = base.pop("dates", None)
+        day_value = base.pop("day", None)
+        days_value = base.pop("days", None)
+        week_value = base.pop("week", None)
+        year_value = base.pop("year", None)
+
+        if date_value:
+            try:
+                day_name, week_num, year_num = _date_components(date_value)
+            except ValueError:
+                continue
+            entry = dict(base)
+            entry["days"] = [day_name]
+            entry["week"] = week_num
+            entry["year"] = year_num
+            results.append(entry)
+            continue
+
+        if isinstance(dates_value, Iterable) and not isinstance(dates_value, (str, bytes)):
+            grouped: Dict[Tuple[int, int], List[str]] = {}
+            for raw_date in dates_value:
+                try:
+                    day_name, week_num, year_num = _date_components(raw_date)
+                except ValueError:
+                    continue
+                key = (week_num, year_num)
+                grouped.setdefault(key, [])
+                if day_name not in grouped[key]:
+                    grouped[key].append(day_name)
+            for (week_num, year_num), day_list in grouped.items():
+                entry = dict(base)
+                entry["days"] = day_list
+                entry["week"] = week_num
+                entry["year"] = year_num
+                results.append(entry)
+            if grouped:
+                continue
+
+        candidate_days: List[str] = []
+        if isinstance(days_value, list):
+            for val in days_value:
+                normalized = _normalize_day_label(val)
+                if normalized:
+                    candidate_days.append(normalized)
+        elif isinstance(days_value, str):
+            normalized = _normalize_day_label(days_value)
+            if normalized:
+                candidate_days.append(normalized)
+
+        if day_value:
+            normalized = _normalize_day_label(day_value)
+            if normalized and normalized not in candidate_days:
+                candidate_days.append(normalized)
+
+        entry = dict(base)
+        if candidate_days:
+            entry["days"] = candidate_days
+
+        week_num = _coerce_int(week_value)
+        year_num = _coerce_int(year_value)
+        if week_num is None and default_week is not None:
+            week_num = _coerce_int(default_week)
+        if year_num is None and default_year is not None:
+            year_num = _coerce_int(default_year)
+        if week_num is not None:
+            entry["week"] = week_num
+        if year_num is not None:
+            entry["year"] = year_num
+
+        results.append(entry)
+
+    return results
+
+
+def map_participants_to_ids(
+    items: Iterable[Mapping[str, Any]],
+    fm_list: Iterable[Mapping[str, Any]],
+) -> List[Dict[str, Any]]:
+    id_set = {str(member.get("id")) for member in fm_list if member.get("id") is not None}
+    name_to_id = {
+        str(member.get("name", "")).strip().lower(): str(member.get("id"))
+        for member in fm_list
+        if member.get("name")
+    }
+
+    strict = _strict_unknown_participants()
+    results: List[Dict[str, Any]] = []
+
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        raw_participants = item.get("participants") or []
+        mapped: List[str] = []
+        unknowns: List[str] = []
+        for participant in raw_participants:
+            if participant is None:
+                continue
+            identifier = str(participant).strip()
+            if not identifier:
+                continue
+            if identifier in id_set:
+                if identifier not in mapped:
+                    mapped.append(identifier)
+                continue
+            name_lookup = name_to_id.get(identifier.lower())
+            if name_lookup:
+                if name_lookup not in mapped:
+                    mapped.append(name_lookup)
+            else:
+                unknowns.append(identifier)
+
+        if strict and unknowns:
+            raise ValueError(f"Unknown participants: {', '.join(unknowns)}")
+
+        entry = dict(item)
+        entry["participants"] = mapped
+        results.append(entry)
+
+    return results
+
+
+def ensure_required_fields(items: Iterable[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    required = {"name", "startTime", "endTime", "participants", "days", "week", "year"}
+    results: List[Dict[str, Any]] = []
+
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        if not required.issubset(item.keys()):
+            continue
+
+        name = item.get("name")
+        start_time = item.get("startTime")
+        end_time = item.get("endTime")
+        participants = item.get("participants")
+        days = item.get("days")
+        week = _coerce_int(item.get("week"))
+        year = _coerce_int(item.get("year"))
+
+        if not isinstance(name, str) or not name.strip():
+            continue
+        if not isinstance(start_time, str) or not isinstance(end_time, str):
+            continue
+        if not isinstance(participants, list):
+            continue
+        if not isinstance(days, list) or not days:
+            continue
+
+        normalized_days = []
+        for day in days:
+            normalized = _normalize_day_label(day)
+            if normalized and normalized not in normalized_days:
+                normalized_days.append(normalized)
+
+        if not normalized_days or week is None or year is None:
+            continue
+
+        entry = dict(item)
+        entry["name"] = name.strip()
+        entry["startTime"] = start_time.strip()
+        entry["endTime"] = end_time.strip()
+        entry["participants"] = [str(pid) for pid in entry.get("participants", [])]
+        entry["days"] = normalized_days
+        entry["week"] = week
+        entry["year"] = year
+        results.append(entry)
+
+    return results
+
+
+def normalize_and_align(
+    items: Iterable[Mapping[str, Any]],
+    fm_list: Iterable[Mapping[str, Any]],
+    default_week: Optional[int] = None,
+    default_year: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    expanded = expand_dates_to_week_schema(items, default_week=default_week, default_year=default_year)
+    mapped = map_participants_to_ids(expanded, fm_list)
+    return ensure_required_fields(mapped)

--- a/services/llm_client.py
+++ b/services/llm_client.py
@@ -1,0 +1,103 @@
+"""Lightweight client for calling external language models."""
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any, Dict, List
+
+import requests
+from requests import RequestException
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+
+class LLMError(Exception):
+    """Raised when the LLM returns an unexpected or invalid response."""
+
+
+PROVIDER = os.getenv("LLM_PROVIDER", "anthropic")
+MODEL = os.getenv("LLM_MODEL", "claude-3-5-sonnet-20240620")
+API_KEY = os.getenv("LLM_API_KEY", "")
+TIMEOUT = int(os.getenv("LLM_HTTP_TIMEOUT_SECONDS", "25"))
+MAX_TOKENS = int(os.getenv("AI_PARSE_MAX_TOKENS", "1024"))
+
+
+def _anthropic_endpoint() -> str:
+    return "https://api.anthropic.com/v1/messages"
+
+
+def _anthropic_headers() -> Dict[str, str]:
+    return {
+        "content-type": "application/json",
+        "x-api-key": API_KEY,
+        "anthropic-version": "2023-06-01",
+    }
+
+
+def _extract_first_json_blob(text: str) -> str:
+    """Extract the first JSON object/array found in ``text``."""
+
+    if not text:
+        raise LLMError("No content returned from LLM response")
+
+    block = re.search(r"```(?:json)?\s*(\{.*?\}|\[.*?\])\s*```", text, re.S)
+    if block:
+        return block.group(1)
+
+    brace = re.search(r"(\{.*\})", text, re.S)
+    bracket = re.search(r"(\[.*\])", text, re.S)
+    candidate = (brace.group(1) if brace else None) or (bracket.group(1) if bracket else None)
+    if not candidate:
+        raise LLMError("No JSON found in LLM response")
+    return candidate
+
+
+def _extract_text_from_response(payload: Dict[str, Any]) -> str:
+    content = payload.get("content")
+    if isinstance(content, list) and content:
+        segment = content[0]
+        if isinstance(segment, dict):
+            return str(segment.get("text", ""))
+    return ""
+
+
+@retry(
+    reraise=True,
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=0.8, min=1, max=6),
+    retry=retry_if_exception_type((RequestException, LLMError)),
+)
+def parse_schedule_with_llm(prompt: str) -> List[Dict[str, Any]]:
+    """Send ``prompt`` to the configured LLM provider and parse the JSON array."""
+
+    if PROVIDER != "anthropic":
+        raise LLMError(f"Unsupported provider: {PROVIDER}")
+    if not API_KEY:
+        raise LLMError("LLM_API_KEY is not configured")
+
+    payload = {
+        "model": MODEL,
+        "max_tokens": MAX_TOKENS,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+
+    response = requests.post(
+        _anthropic_endpoint(),
+        headers=_anthropic_headers(),
+        json=payload,
+        timeout=TIMEOUT,
+    )
+    response.raise_for_status()
+    data = response.json()
+    text = _extract_text_from_response(data)
+    json_blob = _extract_first_json_blob(text)
+
+    try:
+        activities = json.loads(json_blob)
+    except json.JSONDecodeError as exc:
+        raise LLMError("Failed to decode JSON from LLM response") from exc
+
+    if not isinstance(activities, list):
+        raise LLMError("Expected a JSON array of activities")
+
+    return activities

--- a/services/prompts.py
+++ b/services/prompts.py
@@ -1,0 +1,77 @@
+"""Prompt builders for AI-assisted schedule parsing."""
+from __future__ import annotations
+
+from textwrap import dedent
+from typing import Iterable, Mapping, Optional
+
+SWEDISH_DAYS = '["Måndag","Tisdag","Onsdag","Torsdag","Fredag","Lördag","Söndag"]'
+
+
+def _format_family_members(family_members: Iterable[Mapping[str, object]]) -> str:
+    lines: list[str] = []
+    for member in family_members:
+        name = str(member.get("name", "")).strip()
+        identifier = member.get("id")
+        if not name:
+            continue
+        lines.append(f'- "{name}" (id: {identifier})')
+    return "\n".join(lines)
+
+
+def build_parse_prompt(
+    natural_text: str,
+    family_members: Iterable[Mapping[str, object]],
+    week: Optional[int],
+    year: Optional[int],
+) -> str:
+    """Build a strict prompt instructing the LLM to return activity JSON.
+
+    Parameters
+    ----------
+    natural_text:
+        The free-form schedule text submitted by the user.
+    family_members:
+        Iterable containing dict-like objects with ``name`` and ``id`` keys.
+    week, year:
+        Optional ISO week/year context that helps the model interpret relative
+        descriptions.
+    """
+
+    natural_text = (natural_text or "").strip()
+    if not natural_text:
+        raise ValueError("natural_text must be a non-empty string")
+
+    fm_lines = _format_family_members(family_members)
+    week_year = f"Vecka: {week}, År: {year}" if week and year else "Vecka/år: (ej specificerat)"
+
+    return dedent(
+        f"""
+        Du är en schemaläggningsassistent. Svara ENBART med en JSON-array (ingen extra text, inga kodblock).
+        Familjemedlemmar (namn → id):
+        {fm_lines or "- (inga)"}
+        Kontextramar: {week_year}
+
+        OBLIGATORISKT OUTPUTSCHEMA (inga "date"/"dates" fält):
+        [
+          {{
+            "name": string,
+            "icon": string (valfritt),
+            "participants": [string],     // FYLL ENDAST MED FAMILYMEMBER-ID (inte namn)
+            "startTime": "HH:MM",         // 24h
+            "endTime": "HH:MM",
+            "days": {SWEDISH_DAYS},       // en eller flera av dessa strängar
+            "week": number,               // ISO-vecka
+            "year": number                // ISO-år
+          }}
+        ]
+
+        Regler:
+        - Deltagare: använd exakt id från listan ovan. Okända -> utelämna.
+        - Om texten anger exakta datum (t.ex. "2025-10-03"), konvertera själv till rätt "days"/"week"/"year".
+        - Tider: 24h "HH:MM".
+        - Svara endast med JSON-array enligt schemat ovan.
+
+        Fritext:
+        \"\"\"{natural_text}\"\"\"
+        """
+    ).strip()

--- a/tests/test_ai_parse_schedule.py
+++ b/tests/test_ai_parse_schedule.py
@@ -1,0 +1,192 @@
+import os
+import sys
+import jwt
+import pytest
+from flask import Flask
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from services.db_config import db
+from api.schedule_routes import schedule_bp
+from services.ai_postprocess import normalize_and_align
+from services.llm_client import LLMError
+from models.user import User
+from models.schedule_models import FamilyMember
+from config.settings import SECRET_KEY
+
+
+@pytest.fixture
+def ai_client():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
+        'poolclass': StaticPool,
+        'connect_args': {'check_same_thread': False},
+    }
+    app.config['SECRET_KEY'] = SECRET_KEY
+
+    db.init_app(app)
+    app.register_blueprint(schedule_bp, url_prefix='/api/schedule')
+
+    with app.app_context():
+        db.create_all()
+        user = User(id=User.generate_id(), username='tester')
+        user.set_password('pw')
+        db.session.add(user)
+        db.session.flush()
+
+        fm1 = FamilyMember(name='Rut', color='#111111', icon='😀', user_id=user.id)
+        fm2 = FamilyMember(name='Bo', color='#222222', icon='😀', user_id=user.id)
+        db.session.add_all([fm1, fm2])
+        db.session.commit()
+
+        token = jwt.encode({'user_id': user.id}, SECRET_KEY, algorithm='HS256')
+        member_ids = {fm.name: fm.id for fm in FamilyMember.query.all()}
+
+    client = app.test_client()
+    client.environ_base['HTTP_AUTHORIZATION'] = f'Bearer {token}'
+
+    yield client, app, member_ids
+
+    with app.app_context():
+        db.drop_all()
+
+
+def test_normalize_maps_participants_and_dates():
+    fm = [{'id': '1', 'name': 'Rut'}, {'id': '2', 'name': 'Bo'}]
+    items = [{
+        'name': 'Fotboll',
+        'startTime': '16:00',
+        'endTime': '17:30',
+        'participants': ['Rut', '2', 'Okänd'],
+        'date': '2025-10-03',
+    }]
+
+    result = normalize_and_align(items, fm)
+    assert len(result) == 1
+    entry = result[0]
+    assert entry['participants'] == ['1', '2']
+    assert entry['days'] == ['Fredag']
+    assert entry['week'] == 40
+    assert entry['year'] == 2025
+
+
+def test_normalize_requires_fields():
+    fm = [{'id': '1', 'name': 'Rut'}]
+    items = [{
+        'name': '',
+        'startTime': '10:00',
+        'endTime': '11:00',
+        'participants': ['Rut'],
+        'days': ['Måndag'],
+        'week': 1,
+        'year': 2025,
+    }]
+
+    assert normalize_and_align(items, fm) == []
+
+
+def test_normalize_strict_unknown_participant(monkeypatch):
+    monkeypatch.setenv('AI_PARSE_STRICT_UNKNOWN_PARTICIPANTS', '1')
+    fm = [{'id': '1', 'name': 'Rut'}]
+    items = [{
+        'name': 'Träning',
+        'startTime': '10:00',
+        'endTime': '11:00',
+        'participants': ['Unknown'],
+        'days': ['Måndag'],
+        'week': 1,
+        'year': 2025,
+    }]
+
+    with pytest.raises(ValueError):
+        normalize_and_align(items, fm)
+
+
+def test_ai_parse_schedule_success(ai_client, monkeypatch):
+    client, app, member_ids = ai_client
+    rut_id = member_ids['Rut']
+    bo_id = member_ids['Bo']
+
+    sample_response = [{
+        'name': 'Fotboll',
+        'participants': ['Rut', bo_id],
+        'startTime': '16:00',
+        'endTime': '17:30',
+        'date': '2025-10-03',
+    }]
+
+    monkeypatch.setattr('api.schedule_routes.parse_schedule_with_llm', lambda prompt: sample_response)
+
+    response = client.post('/api/schedule/ai-parse-schedule', json={'text': 'Rut spelar fotboll'})
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload['success'] is True
+    activity = payload['data']['activities'][0]
+    assert activity['participants'] == [rut_id, bo_id]
+    assert activity['days'] == ['Fredag']
+    assert activity['week'] == 40
+    assert activity['year'] == 2025
+
+
+def test_ai_parse_schedule_unknown_participant_dropped(ai_client, monkeypatch):
+    client, app, member_ids = ai_client
+
+    sample_response = [{
+        'name': 'Solo',
+        'participants': ['Unknown'],
+        'startTime': '09:00',
+        'endTime': '10:00',
+        'days': ['Måndag'],
+        'week': 12,
+        'year': 2025,
+    }]
+
+    monkeypatch.setattr('api.schedule_routes.parse_schedule_with_llm', lambda prompt: sample_response)
+
+    response = client.post('/api/schedule/ai-parse-schedule', json={'text': 'Solo aktivitet'})
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload['data']['activities'][0]['participants'] == []
+
+
+def test_ai_parse_schedule_unknown_participant_strict(ai_client, monkeypatch):
+    client, app, member_ids = ai_client
+    monkeypatch.setenv('AI_PARSE_STRICT_UNKNOWN_PARTICIPANTS', '1')
+
+    sample_response = [{
+        'name': 'Solo',
+        'participants': ['Unknown'],
+        'startTime': '09:00',
+        'endTime': '10:00',
+        'days': ['Måndag'],
+        'week': 12,
+        'year': 2025,
+    }]
+
+    monkeypatch.setattr('api.schedule_routes.parse_schedule_with_llm', lambda prompt: sample_response)
+
+    response = client.post('/api/schedule/ai-parse-schedule', json={'text': 'Solo aktivitet'})
+    assert response.status_code == 422
+    payload = response.get_json()
+    assert 'Unknown participants' in payload['error']
+
+
+def test_ai_parse_schedule_requires_text(ai_client):
+    client, app, member_ids = ai_client
+    response = client.post('/api/schedule/ai-parse-schedule', json={'text': ''})
+    assert response.status_code == 400
+
+
+def test_ai_parse_schedule_llm_failure(ai_client, monkeypatch):
+    client, app, member_ids = ai_client
+
+    def _raise(*args, **kwargs):
+        raise LLMError('boom')
+
+    monkeypatch.setattr('api.schedule_routes.parse_schedule_with_llm', _raise)
+
+    response = client.post('/api/schedule/ai-parse-schedule', json={'text': 'Hej'})
+    assert response.status_code == 502


### PR DESCRIPTION
## Summary
- add prompt builder, LLM client, and normalization utilities for AI schedule parsing
- expose POST /api/schedule/ai-parse-schedule endpoint that validates activities without persistence
- extend requirements and add tests covering normalization and endpoint behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdc0a51f748323874af512f0012f32