### PR TITLE
Refactor LLM config lookup and add AI health endpoint

### DIFF
--- a/api/schedule_routes.py
+++ b/api/schedule_routes.py
@@ -3,7 +3,7 @@ from services.db_config import db
 from models.schedule_models import Activity, FamilyMember, Settings
 from api.auth_routes import token_required
 from services.prompts import build_parse_prompt
-from services.llm_client import LLMError, parse_schedule_with_llm
+from services.llm_client import LLMError, is_llm_configured, parse_schedule_with_llm
 from services.ai_postprocess import normalize_and_align
 
 from requests import RequestException
@@ -736,7 +736,7 @@ def ai_parse_schedule(current_user):
         aligned = [ensure_series_id(activity) for activity in aligned]
     except LLMError as exc:
         logger.warning("LLM parse error for user %s: %s", current_user.id, exc)
-        return error_response("Kunde inte tolka AI-svar.", 502)
+        return error_response(str(exc), 503)
     except Timeout:
         logger.warning("LLM request timeout for user %s", current_user.id)
         return error_response("AI-tjänsten tog för lång tid att svara.", 502)
@@ -770,6 +770,14 @@ def ai_parse_schedule(current_user):
         return error_response("AI returnerade inga giltiga aktiviteter efter normalisering.", 422)
 
     return success_response({"activities": validated})
+
+
+@schedule_bp.route("/ai/health", methods=["GET"])
+@token_required
+def ai_health(current_user):
+    """Health endpoint indicating whether LLM configuration is present."""
+
+    return success_response({"configured": is_llm_configured()})
 
 
 @schedule_bp.route("/add-activities", methods=["POST"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-SQLAlchemy
 PyMySQL
 bcrypt
 PyJWT
-python-dotenv
+python-dotenv>=1.0,<2
 requests>=2.32.0
-tenacity>=8.2.0
+tenacity>=8.2,<9
 python-dateutil>=2.9.0


### PR DESCRIPTION
## Summary
- lazily read and cache LLM provider configuration when first needed
- expose configuration status through a new is_llm_configured helper and /api/schedule/ai/health endpoint
- tighten python-dotenv and tenacity dependency ranges to guarantee availability

## Testing
- pytest tests/test_ai_parse_schedule.py *(fails: existing SQLAlchemy mapper initialisation errors in test fixture setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e24373dc3083238800272aae92013c